### PR TITLE
Fixed GPS bug

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -65,6 +65,9 @@ Citizen.CreateThread(function()
                     SendNUIMessage({
                         type = "disablecam",
                     })
+			if SecurityCamConfig.HideRadar then
+                    	   DisplayRadar(true)
+                	end
                 end
 
                 -- GO BACK CAMERA


### PR DESCRIPTION
Fixed so when you close the cameras, you will automaticly get back your GPS again if you have SecurityCamConfig.HideRadar = true in your config.